### PR TITLE
Added the HateXplain dataset

### DIFF
--- a/highlights/index.md
+++ b/highlights/index.md
@@ -31,6 +31,7 @@ title: Highlights
 | [Kutlu et al. (2020)](https://www.ischool.utexas.edu/~ml/papers/kutlu_jair20.pdf) | webpage relevance ranking | 2-3 sentences | crowd | 700 | 15 | n/a |
 | [Supporting Context for Ambiguous Translations (SCAT)](https://arxiv.org/abs/2105.06977) | Document-level En-Fr MT | none | experts | ~14K | 1 | 20 |   
 | [ECtHR](https://www.aclweb.org/anthology/2021.naacl-main.22/) | alleged legal violation prediction | paragraphs | auto + expert | ~11K | 1 | n/a |               
+| [HateXplain](https://arxiv.org/abs/2012.10289) | hate-speech classification | phrases | crowd | 20148 | 3 | 253 |               
 
 ## French
 


### PR DESCRIPTION
Added an entry for the HateXplain hate-speech classification dataset (https://arxiv.org/abs/2012.10289) under the highlights category